### PR TITLE
Handle splitting by forward or backward slash depending on operation system

### DIFF
--- a/write_the/commands/mkdocs/mkdocs.py
+++ b/write_the/commands/mkdocs/mkdocs.py
@@ -1,3 +1,5 @@
+import sys
+
 from pathlib import Path
 from collections import defaultdict
 from write_the.utils import list_python_files
@@ -41,7 +43,13 @@ def write_the_mkdocs(
             ) or f"{code_dir.name}/{group}." in str(file):
                 key = group
                 break
-        module = str(file).rstrip(".py").replace("/", ".")  # breaks on windows?
+
+        if sys.platform.startswith("win32") or sys.platform.startswith("cygwin"):
+            splitter = "\\"
+        else:
+            splitter = "/"
+        module = module.replace(splitter, ".")
+
         references[key].append(f"::: {module}")
     docs_dir = out_dir / "docs"
     reference_path = docs_dir / "reference"

--- a/write_the/commands/mkdocs/mkdocs.py
+++ b/write_the/commands/mkdocs/mkdocs.py
@@ -44,6 +44,7 @@ def write_the_mkdocs(
                 key = group
                 break
 
+        module = str(file).rsplit(".py")[0]
         if sys.platform.startswith("win32") or sys.platform.startswith("cygwin"):
             splitter = "\\"
         else:


### PR DESCRIPTION
Hi all,

I used this cool package on a windows machine and had the predicted case that the python file names were not splitted correctly.

### OS Check
So the file
````
src/mod1/mod2/test.py 
````
resulted in the docs/reference/index.md file to
````
::: src/mod1/mod2/test
instead of the correct
::: src.mod1.mod2.test
````

### str.rstrip() removes ps infront of .py
Additionally there was an error with files that ended on a 'p' like this file

````
src/fastapi-app/mod/app.py 
````
resulted in the docs/reference/index.md file to
````
::: src/fastapi-app/mod/a
instead of the correct
::: src/fastapi-app/mod/app
````

I ran the test locally so that looks good.

Kind regards.